### PR TITLE
update 0.4.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: True  #[py<38]
+  skip: True  #[py<38 or s390x]
+  # skipping s390x as it is not available for numba or pyarrow
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -42,9 +43,18 @@ test:
 
 about:
   home: https://github.com/holoviz/spatialpandas
+  description: |
+    Spatialpandas provides Pandas and Dask extensions for vectorized
+    spatial and geometric operations, such as fast, spatially indexed
+    rendering of large collections of polygons, lines, or points.
   summary: Pandas extension arrays for spatial/geometric operations
   license: BSD-2-Clause
   license_file: LICENSE
+  license_family: BSD
+  dev_url: https://pypi.org/project/spatialpandas/
+  doc_url: https://github.com/holoviz/spatialpandas/blob/main/README.md
+
+
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,14 +11,17 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  #[py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
-    - python >=3.8
+    - python
     - param
+    - pyct >=0.4.4
+    - wheel
+    - setuptools
   run:
     - dask-core
     - fsspec
@@ -26,7 +29,7 @@ requirements:
     - pandas
     - param
     - pyarrow >=1.0
-    - python >=3.8
+    - python
     - retrying
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,7 @@ requirements:
   host:
     - pip
     - python
-    - param
-    - pyct >=0.4.4
+    - param 1.13.0
     - wheel
     - setuptools
   run:


### PR DESCRIPTION
## Spatialpandas 0.4.8 Update
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2124)
[Upstream](https://github.com/holoviz/spatialpandas)
[Dependencies ](https://github.com/holoviz/spatialpandas/blob/main/setup.py)
# Changes
- Updated version number and `sha256.`
- Updated pinnings on dependencies
- There is no support for `s390x` `pyarrow` and `numba` so it has been skipped.