### PR TITLE
Update to 0.4.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "spatialpandas" %}
-{% set version = "0.4.9" %}
+{% set version = "0.4.10" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 666c7b33fe0e8516b88029beaf23f7260375ec42997e5a2e40b3e689d73f28cf
+  sha256: 032e24ebb40f75c5c79cb79d7c281f2990e69ba382c0b24acb53da7bba60851c
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  #[py<38 or s390x]
+  skip: True  #[py<39 or s390x]
   # skipping s390x as it is not available for numba or pyarrow
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
@@ -19,9 +19,10 @@ requirements:
   host:
     - pip
     - python
-    - param 1.13.0
+    - param >=1.7.0
     - wheel
-    - setuptools
+    - pyct >=0.4.4
+    - setuptools >=30.3.0
   run:
     - dask-core
     - fsspec

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,10 +19,10 @@ requirements:
   host:
     - pip
     - python
-    - param >=1.7.0
+    - param
     - wheel
-    - pyct >=0.4.4
-    - setuptools >=30.3.0
+    - pyct
+    - setuptools
   run:
     - dask-core
     - fsspec


### PR DESCRIPTION
spatialpandas 0.4.10

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/spatialpandas)
- [Upstream changelog/diff](https://github.com/holoviz/spatialpandas/releases/tag/v0.4.10)

### Explanation of changes:

- Same as https://github.com/conda-forge/spatialpandas-feedstock/pull/17
