### PR TITLE
release 0.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - dask-core >=2025.1
     - fsspec >=2022.8
     - numba
+    - packaging
     - pandas >=2.0
     - pyarrow >=14.0.1
     - retrying

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,36 +1,33 @@
 {% set name = "spatialpandas" %}
-{% set version = "0.4.10" %}
+{% set version = "0.5.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 032e24ebb40f75c5c79cb79d7c281f2990e69ba382c0b24acb53da7bba60851c
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 412bb93bb25f49b6c057e825560d14c06e71137228fa99dc007b3a191bfbabd1
 
 build:
   number: 0
-  skip: True  #[py<39 or s390x]
+  skip: True  #[py<310 or s390x]
   # skipping s390x as it is not available for numba or pyarrow
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
+    - python
     - pip
-    - python
-    - param
-    - wheel
-    - pyct
-    - setuptools
+    - hatchling
+    - hatch-vcs
   run:
-    - dask-core
-    - fsspec
-    - numba
-    - pandas
-    - param
-    - pyarrow >=1.0
     - python
+    - dask-core >=2025.1
+    - fsspec >=2022.8
+    - numba
+    - pandas >=2.0
+    - pyarrow >=14.0.1
     - retrying
 
 test:
@@ -57,6 +54,6 @@ about:
 extra:
   recipe-maintainers:
     - andrewannex
-    - ianthomas23
+    - hoxbro
     - maximlt
     - philippjfr


### PR DESCRIPTION
spatialpandas 0.5.0

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/spatialpandas)
- [Upstream changelog/diff](https://github.com/holoviz/spatialpandas/compare/v0.4.10...v0.5.0)
